### PR TITLE
Fix problem when using npm install vui-button result resolution error

### DIFF
--- a/button.scss
+++ b/button.scss
@@ -1,5 +1,5 @@
 @import 'bower_components/vui-colors/colors.scss';
-@import 'bower_components/vui-typography/small-text.scss';
+@import 'node_modules/vui-typography/small-text.scss';
 
 @mixin _vui-button(
 		$color,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "bower": "^1.4.1"
+    "bower": "^1.4.1",
+    "vui-typography": "^2.0.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.1.2",


### PR DESCRIPTION
This problem happens when you have a npm package `mypackage`, which list `vui-button` as a dependency. 

When you run `npm i`, it will install `vui-button`, the postinstall script of `vui-button` will run `bower i` which pulled in the two dependencies: `vui-colors, vui-typography`. However, `vui-typography` itself does have other bower dependencies, in particular, it expects `mypackage/node_modules/vui-button/bower_components/vui-typography/bower_components/vui-colors/colors.scss" exists for `mypackage/node_modules/vui-button/bower_components/vui-typography/small-text.scss`. 

Bower won't honor the nested dependency and the path resolution of `vui-typography` will fail when compiling the sass. Although `vui-typography` does have a postinstall script to run `bower i` but only npm will run it, when `vui-typography` is installed through bower (which is by the postinstall script of `vui-button`), it won't happen.

https://github.com/bower/bower/issues/157

For similar reasons, please don't use bower for more than one level of dependencies, or don't use it at all.

FYI:
@AlexBedley @csilcock 